### PR TITLE
[feat] Retrieves download links with permission for photos in Photo component

### DIFF
--- a/src/components/Photo.jsx
+++ b/src/components/Photo.jsx
@@ -1,20 +1,36 @@
 import styles from '../styles/photo'
 
-import React from 'react'
+import React, { Component } from 'react'
 import { Link, withRouter } from 'react-router'
 
-import { STACK_FILES_DOWNLOAD_PATH } from '../constants/config'
+import { getPhotoLink } from '../actions/photos'
 
-export const Photo = ({ photo, router }) => {
-  const parentPath = router.location.pathname
-  return (
-    <Link to={`${parentPath}/${photo._id}`}>
-      <img
-        className={styles['pho-photo-item']}
-        src={`${STACK_FILES_DOWNLOAD_PATH}/${photo._id}`}
-      />
-    </Link>
-  )
+export class Photo extends Component {
+  constructor (props) {
+    super(props)
+
+    this.state = {
+      loading: true
+    }
+    getPhotoLink(props.photo)
+      .then(link => this.setState({
+        url: link,
+        loading: false
+      }))
+  }
+
+  render ({ photo, router }, { loading, url }) {
+    const parentPath = router.location.pathname
+    return (
+      !loading &&
+        <Link to={`${parentPath}/${photo._id}`}>
+          <img
+            className={styles['pho-photo-item']}
+            src={url}
+          />
+        </Link>
+    )
+  }
 }
 
 export default withRouter(Photo)

--- a/src/components/Photo.jsx
+++ b/src/components/Photo.jsx
@@ -19,7 +19,9 @@ export class Photo extends Component {
       }))
   }
 
-  render ({ photo, router }, { loading, url }) {
+  render () {
+    const { photo, router } = this.props
+    const { loading, url } = this.state
     const parentPath = router.location.pathname
     return (
       !loading &&

--- a/test/components/__snapshots__/photosList.spec.jsx.snap
+++ b/test/components/__snapshots__/photosList.spec.jsx.snap
@@ -26,7 +26,7 @@ exports[`PhotosList component should render correctly a timeline of photos accor
     <h3>
       January 0001
     </h3>
-    <withRouter(Component)
+    <withRouter(Photo)
       photo={
         Object {
           "_id": "33dda00f0eec15bc3b3c59a615001ac8",

--- a/test/components/photo.spec.jsx
+++ b/test/components/photo.spec.jsx
@@ -24,7 +24,13 @@ describe('Photo component', () => {
   it('should render correctly an image according a photo object and the router path', () => {
     const component = shallow(
       <Photo photo={photoObject} router={routerObjectMock} />
-    ).node
-    expect(component).toMatchSnapshot()
+    )
+
+    component.setState({
+      loading: false,
+      url: `http://cozy.local:8080/files/download/33dda00f0eec15bc3b3c59a615001ac8`
+    })
+
+    expect(component.node).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
We should quicky think about a caching mechanism to store already fetch photo links (as they are constant)

Featuring a cozy-client-js polyfill experimentation. See https://github.com/cozy/cozy-client-js/pull/99