### PR TITLE
feat: Add Support for editor's name

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -4,6 +4,7 @@
   "icon": "app-icon.svg",
   "description": "Photos manager for Cozy v3",
   "source": "https://github.com/cozy/cozy-photos-v3.git@build",
+  "editor": "Cozy",
   "developer": {
     "name": "Cozy",
     "url": "https://cozy.io"

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -25,5 +25,6 @@
   data-cozy-domain="{{.Domain}}"
   data-cozy-locale="{{.Locale}}"
   data-cozy-app-name="{{.AppName}}"
+  data-cozy-app-editor="{{.AppEditor}}"
   data-cozy-icon-path="{{.IconPath}}"
 >

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -16,7 +16,6 @@ import { I18n } from './lib/I18n'
 import photosApp from './reducers'
 import AppRoute from './components/AppRoute'
 
-const context = window.context
 const lang = document.documentElement.getAttribute('lang') || 'en'
 
 const loggerMiddleware = createLogger()
@@ -30,15 +29,20 @@ const store = createStore(
 )
 
 document.addEventListener('DOMContentLoaded', () => {
-  const applicationElement = document.querySelector('[role=application]')
+  const context = window.context
+  const root = document.querySelector('[role=application]')
+  const data = root.dataset
 
   cozy.client.init({
-    cozyURL: `//${applicationElement.dataset.cozyDomain}`,
-    token: applicationElement.dataset.cozyToken
+    cozyURL: `//${data.cozyDomain}`,
+    token: data.cozyToken
   })
 
   cozy.bar.init({
-    appName: 'Photos'
+    appName: data.cozyAppName,
+    appEditor: data.cozyAppEditor,
+    iconPath: data.cozyIconPath,
+    lang: data.cozyLocale
   })
 
   render((
@@ -47,5 +51,5 @@ document.addEventListener('DOMContentLoaded', () => {
         <Router history={hashHistory} routes={AppRoute} />
       </Provider>
     </I18n>
-  ), applicationElement)
+  ), root)
 })


### PR DESCRIPTION
Adding Editor's name to the manifest so the stack can use it and make sure this data is shared so the cozy-bar can use it.

tl;dr: It displays the "Cozy" before the "Photos" in the Cozy-bar

Related PR: https://github.com/cozy/cozy-bar/pull/37
