### PR TITLE
feat: Hide trashed photos from Timeline

### DIFF
--- a/src/actions/mango.js
+++ b/src/actions/mango.js
@@ -17,7 +17,7 @@ import {
 export const indexFilesByDate = () => {
   return async dispatch => {
     dispatch({ type: INDEX_FILES_BY_DATE })
-    const fields = [ 'class', 'created_at' ]
+    const fields = [ 'class', 'trashed', 'created_at' ]
     return await cozy.client.data.defineIndex(FILE_DOCTYPE, fields)
       .then((mangoIndexByDate) => {
         dispatch({

--- a/src/actions/photos.js
+++ b/src/actions/photos.js
@@ -29,7 +29,8 @@ export const fetchPhotos = (mangoIndexByDate) => {
     dispatch({ type: FETCH_PHOTOS, mangoIndexByDate })
     const options = {
       selector: {
-        class: 'image'
+        class: 'image',
+        trashed: false
       },
       fields: ['_id', 'dir_id', 'created_at', 'name', 'size', 'updated_at', 'metadata'],
       descending: true

--- a/test/actions/mango.spec.js
+++ b/test/actions/mango.spec.js
@@ -18,7 +18,7 @@ const mockMangoIndexByDate = {
   doctype: 'io.cozy.files',
   type: 'mango',
   name: '_design/54d3474c4efdfe10d790425525e56433857955a1',
-  fields: ['class', 'created_at']
+  fields: ['class', 'trashed', 'created_at']
 }
 
 beforeAll(() => {
@@ -53,7 +53,7 @@ describe('indexFilesByDate', () => {
         expect(cozy.client.data.defineIndex.mock.calls.length).toBe(1)
         expect(cozy.client.data.defineIndex.mock.calls[0][0]).toBe(FILE_DOCTYPE)
         expect(cozy.client.data.defineIndex.mock.calls[0][1]).toEqual(
-          [ 'class', 'created_at' ])
+          [ 'class', 'trashed', 'created_at' ])
         expect(store.getActions()).toEqual(expectedActions)
       })
   })


### PR DESCRIPTION
FYI: In the file `mango.js` the order of the items in `fields` array matters.
The fields you want to filter with must be on the left of the field you want to sort with.
Basically, first you filter then you sort.