### PR TITLE
Fix/sort datetime

### DIFF
--- a/src/actions/photos.js
+++ b/src/actions/photos.js
@@ -32,7 +32,7 @@ export const fetchPhotos = (mangoIndexByDate) => {
         class: 'image',
         trashed: false
       },
-      fields: ['_id', 'dir_id', 'created_at', 'name', 'size', 'updated_at', 'metadata'],
+      fields: ['_id', 'dir_id', 'name', 'size', 'updated_at', 'metadata'],
       descending: true
     }
     return await cozy.client.data.query(mangoIndexByDate, options)

--- a/src/components/PhotoList.jsx
+++ b/src/components/PhotoList.jsx
@@ -15,7 +15,7 @@ export class PhotoList extends Component {
     const { key, title, photos, selected, onPhotoToggle, containerWidth } = this.props
     // @see https://flickr.github.io/justified-layout/
     const layout = justifiedLayout(
-      photos.map(photo => photo.metadata || photoDimensionsFallback),
+      photos.map(photo => photo.metadata && photo.metadata.width && photo.metadata.height ? photo.metadata : photoDimensionsFallback),
       {
         containerWidth: containerWidth,
         targetRowHeight: adaptRowHeight(containerWidth),

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -3,7 +3,7 @@ export const getPhotosByMonth = ({ photos }) => {
   photos.forEach(p => {
     // here we want to get an object whose keys are months in a l10able format
     // so we only keep the year and month part of the date
-    const month = p.created_at.slice(0, 7) + '-01T00:00'
+    const month = p.metadata.datetime.slice(0, 7) + '-01T00:00'
     /* istanbul ignore else */
     if (!months.hasOwnProperty(month)) {
       months[month] = []

--- a/test/actions/photos.spec.js
+++ b/test/actions/photos.spec.js
@@ -24,7 +24,9 @@ import client from 'cozy-client-js'
 const mockFetchedPhotos = [
   {
     _id: '33dda00f0eec15bc3b3c59a615001ac8',
-    created_at: '0001-01-01T00:00:00Z',
+    metadata: {
+      datetime: '0001-01-01T00:00:00Z'
+    },
     name: 'MonImage.jpg',
     size: '150000',
     updated_at: '0001-01-01T00:00:00Z'
@@ -38,7 +40,9 @@ const mockUploadedPhoto = {
     type: 'file',
     name: 'MonImage.jpg',
     dir_id: 'io.cozy.files.root-dir',
-    created_at: '0001-01-01T00:00:00Z',
+    metadata: {
+      datetime: '0001-01-01T00:00:00Z'
+    },
     updated_at: '0001-01-01T00:00:00Z',
     size: '150000',
     md5sum: 'wul1lk+i94dp3H5Dq+O54w==',
@@ -153,7 +157,7 @@ const mangoIndexByDateObject = {
   doctype: 'io.cozy.files',
   type: 'mango',
   name: '_design/54d3474c4efdfe10d790425525e56433857955a1',
-  fields: ['class', 'created_at']
+  fields: ['class', 'metadata.datetime']
 }
 
 describe('fetchPhotos', () => {

--- a/test/components/__snapshots__/photoList.spec.jsx.snap
+++ b/test/components/__snapshots__/photoList.spec.jsx.snap
@@ -22,8 +22,10 @@ exports[`PhotoList component should render correctly a timeline of photos accord
     photo={
       Object {
         "_id": "33dda00f0eec15bc3b3c59a615001ac8",
-        "created_at": "0001-01-01T00:00:00Z",
         "dir_id": "22545465ezfzef4664686446648684",
+        "metadata": Object {
+          "datetime": "0001-01-01T00:00:00Z",
+        },
         "name": "MonImage.jpg",
         "size": "150000",
         "updated_at": "0001-01-01T00:00:00Z",
@@ -57,8 +59,10 @@ exports[`PhotoList component should render correctly if some photos are selected
     photo={
       Object {
         "_id": "33dda00f0eec15bc3b3c59a615001ac8",
-        "created_at": "0001-01-01T00:00:00Z",
         "dir_id": "22545465ezfzef4664686446648684",
+        "metadata": Object {
+          "datetime": "0001-01-01T00:00:00Z",
+        },
         "name": "MonImage.jpg",
         "size": "150000",
         "updated_at": "0001-01-01T00:00:00Z",
@@ -92,8 +96,10 @@ exports[`PhotoList component should render correctly when a containerWidth is gi
     photo={
       Object {
         "_id": "33dda00f0eec15bc3b3c59a615001ac8",
-        "created_at": "0001-01-01T00:00:00Z",
         "dir_id": "22545465ezfzef4664686446648684",
+        "metadata": Object {
+          "datetime": "0001-01-01T00:00:00Z",
+        },
         "name": "MonImage.jpg",
         "size": "150000",
         "updated_at": "0001-01-01T00:00:00Z",

--- a/test/components/photo.spec.jsx
+++ b/test/components/photo.spec.jsx
@@ -14,7 +14,9 @@ import { Photo } from '../../src/components/Photo'
 
 const photoObject = {
   _id: '33dda00f0eec15bc3b3c59a615001ac8',
-  created_at: '0001-01-01T00:00:00Z',
+  metadata: {
+    datetime: '0001-01-01T00:00:00Z'
+  },
   name: 'MonImage.jpg',
   size: '150000',
   updated_at: '0001-01-01T00:00:00Z'

--- a/test/components/photoList.spec.jsx
+++ b/test/components/photoList.spec.jsx
@@ -11,7 +11,9 @@ const photosMock = [
   {
     _id: '33dda00f0eec15bc3b3c59a615001ac8',
     dir_id: '22545465ezfzef4664686446648684',
-    created_at: '0001-01-01T00:00:00Z',
+    metadata: {
+      datetime: '0001-01-01T00:00:00Z'
+    },
     name: 'MonImage.jpg',
     size: '150000',
     updated_at: '0001-01-01T00:00:00Z'

--- a/test/containers/__snapshots__/photoBoard.spec.jsx.snap
+++ b/test/containers/__snapshots__/photoBoard.spec.jsx.snap
@@ -36,8 +36,10 @@ exports[`PhotoBoard component should render correctly a timeline of photos accor
       Array [
         Object {
           "_id": "33dda00f0eec15bc3b3c59a615001ac8",
-          "created_at": "0001-01-01T00:00:00Z",
           "dir_id": "22545465ezfzef4664686446648684",
+          "metadata": Object {
+            "datetime": "0001-01-01T00:00:00Z",
+          },
           "name": "MonImage.jpg",
           "size": "150000",
           "updated_at": "0001-01-01T00:00:00Z",
@@ -60,8 +62,10 @@ exports[`PhotoBoard component should render correctly a timeline of photos accor
       Array [
         Object {
           "_id": "33dda00f0eec15bc3b3c59a615001ac8",
-          "created_at": "0001-01-01T00:00:00Z",
           "dir_id": "22545465ezfzef4664686446648684",
+          "metadata": Object {
+            "datetime": "0001-01-01T00:00:00Z",
+          },
           "name": "MonImage.jpg",
           "size": "150000",
           "updated_at": "0001-01-01T00:00:00Z",

--- a/test/containers/addToAlbumModal.spec.jsx
+++ b/test/containers/addToAlbumModal.spec.jsx
@@ -15,7 +15,9 @@ import { AddToAlbumModal } from '../../src/containers/AddToAlbumModal'
 const mockFetchedPhotos = [
   {
     _id: '33dda00f0eec15bc3b3c59a615001ac8',
-    created_at: '0001-01-01T00:00:00Z',
+    metadata: {
+      datetime: '0001-01-01T00:00:00Z'
+    },
     name: 'MonImage.jpg',
     size: '150000',
     updated_at: '0001-01-01T00:00:00Z'

--- a/test/containers/photoBoard.spec.jsx
+++ b/test/containers/photoBoard.spec.jsx
@@ -19,7 +19,9 @@ const mockFetchedPhotos = [{
     {
       _id: '33dda00f0eec15bc3b3c59a615001ac8',
       dir_id: '22545465ezfzef4664686446648684',
-      created_at: '0001-01-01T00:00:00Z',
+      metadata: {
+        datetime: '0001-01-01T00:00:00Z'
+      },
       name: 'MonImage.jpg',
       size: '150000',
       updated_at: '0001-01-01T00:00:00Z'

--- a/test/ducks/albums.spec.js
+++ b/test/ducks/albums.spec.js
@@ -73,14 +73,18 @@ const mockAlbumsListWithIds = [
 const mockPhotosList = [
   {
     _id: '33dda00f0eec15bc3b3c59a615001ac8',
-    created_at: '0001-01-01T00:00:00Z',
+    metadata: {
+      datetime: '0001-01-01T00:00:00Z'
+    },
     name: 'MonImage.jpg',
     size: '150000',
     updated_at: '0001-01-01T00:00:00Z'
   },
   {
     _id: '33dda00f0eec15bc3b3c59a615001ac9',
-    created_at: '0001-03-01T00:00:00Z',
+    metadata: {
+      datetime: '0001-03-01T00:00:00Z'
+    },
     name: 'MonImage2_february.jpg',
     size: '120000',
     updated_at: '0001-03-01T00:00:00Z'

--- a/test/lib/helpers.spec.js
+++ b/test/lib/helpers.spec.js
@@ -8,21 +8,27 @@ const mockPhotosObject = {
   photos: [
     {
       _id: '33dda00f0eec15bc3b3c59a615001ac8',
-      created_at: '0001-01-01T00:00:00Z',
+      metadata: {
+        datetime: '0001-01-01T00:00:00Z'
+      },
       name: 'MonImage_january.jpg',
       size: '150000',
       updated_at: '0001-01-01T00:00:00Z'
     },
     {
       _id: '33dda00f0eec15bc3b3c59a615001ac9',
-      created_at: '0001-01-10T00:00:00Z',
+      metadata: {
+        datetime: '0001-01-10T00:00:00Z'
+      },
       name: 'MonImage_january.jpg',
       size: '150000',
       updated_at: '0001-01-01T00:00:00Z'
     },
     {
       _id: '33dda00f0eec15bc3b3c59a615001ac0',
-      created_at: '0001-02-01T00:00:00Z',
+      metadata: {
+        datetime: '0001-02-01T00:00:00Z'
+      },
       name: 'MonImage2_february.jpg',
       size: '100000',
       updated_at: '0001-01-01T00:00:00Z'
@@ -36,14 +42,18 @@ const mockExpected = [
     photos: [
       {
         _id: '33dda00f0eec15bc3b3c59a615001ac8',
-        created_at: '0001-01-01T00:00:00Z',
+        metadata: {
+          datetime: '0001-01-01T00:00:00Z'
+        },
         name: 'MonImage_january.jpg',
         size: '150000',
         updated_at: '0001-01-01T00:00:00Z'
       },
       {
         _id: '33dda00f0eec15bc3b3c59a615001ac9',
-        created_at: '0001-01-10T00:00:00Z',
+        metadata: {
+          datetime: '0001-01-10T00:00:00Z'
+        },
         name: 'MonImage_january.jpg',
         size: '150000',
         updated_at: '0001-01-01T00:00:00Z'
@@ -55,7 +65,9 @@ const mockExpected = [
     photos: [
       {
         _id: '33dda00f0eec15bc3b3c59a615001ac0',
-        created_at: '0001-02-01T00:00:00Z',
+        metadata: {
+          datetime: '0001-02-01T00:00:00Z'
+        },
         name: 'MonImage2_february.jpg',
         size: '100000',
         updated_at: '0001-01-01T00:00:00Z'

--- a/test/reducers/mango.spec.js
+++ b/test/reducers/mango.spec.js
@@ -10,7 +10,7 @@ const mockMangoIndexByDate = {
   doctype: 'io.cozy.files',
   type: 'mango',
   name: '_design/54d3474c4efdfe10d790425525e56433857955a1',
-  fields: ['class', 'created_at']
+  fields: ['class', 'metadata.datetime']
 }
 
 const mockMangoIndexAlbumsByName = {

--- a/test/reducers/photos.spec.js
+++ b/test/reducers/photos.spec.js
@@ -12,7 +12,9 @@ import { photos } from '../../src/reducers/photos'
 const mockFetchedPhotos = [
   {
     _id: '33dda00f0eec15bc3b3c59a615001ac8',
-    created_at: '0001-01-01T00:00:00Z',
+    metadata: {
+      datetime: '0001-01-01T00:00:00Z'
+    },
     name: 'MonImage.jpg',
     size: '150000',
     updated_at: '0001-01-01T00:00:00Z'
@@ -24,7 +26,9 @@ const mockUploadedPhoto = mockFetchedPhotos
 const photosFromState = [
   {
     _id: 'f717eb4d94f07737b168d3dbb7002141',
-    created_at: '0001-01-01T00:00:00Z',
+    metadata: {
+      datetime: '0001-01-01T00:00:00Z'
+    },
     name: 'MonPrecedentImage.jpg',
     size: '150000',
     updated_at: '0001-01-01T00:00:00Z'


### PR DESCRIPTION
- [x] Fix sorting by month that was still relying on `created_at` instead of `metadata.datetime`
- [x] Cleaning remaining occurrence of `created_at`
- [x] Updated tests