### PR TITLE
fix: display a message on success or error

### DIFF
--- a/src/containers/SelectionBar.jsx
+++ b/src/containers/SelectionBar.jsx
@@ -55,7 +55,8 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   onAddToAlbum: selected => dispatch(addToAlbum(selected)),
   onRemoveFromAlbum: (selected, album) =>
   dispatch(removeFromAlbum(selected, album))
-  .catch(err => Alerter.error((err.message)))
+   .then(() => Alerter.success('Albums.remove_photos.success', { album_name: album.name }))
+  .catch(() => Alerter.error('Albums.remove_photos.error.generic'))
 })
 
 export default connect(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -81,6 +81,12 @@
       "error": {
         "index_missing": "An albums index must be provided to fetch albums."
       }
+    },
+    "remove_photos": {
+      "success": "The photo has been removed from album %{album_name}",
+      "error": {
+        "generic": "An error occured while removing the photo, please try again."
+      }
     }
   },
   "Viewer": {


### PR DESCRIPTION

![screenshot at 17-03-22](https://cloud.githubusercontent.com/assets/701648/25956612/847247ae-366c-11e7-8d11-5091f111ccbc.png)
![screenshot at 17-03-07](https://cloud.githubusercontent.com/assets/701648/25956613/84964244-366c-11e7-9aab-2f3a69322a36.png)

Some `Alerter` were missing.