### PR TITLE
fix: move app icon to `public/`

### DIFF
--- a/config/webpack.config.copy-files.js
+++ b/config/webpack.config.copy-files.js
@@ -7,6 +7,7 @@ const build = /:production$/.test(process.env.NODE_ENV)
 module.exports = {
   plugins: [
     new CopyPlugin([
+      { from: 'vendor/assets/app-icon.svg', to: 'public/app-icon.svg' },
       { from: 'vendor/assets', ignore: ['.gitkeep'] },
       { from: 'manifest.webapp', transform: transformManifest }
     ])

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "Photos",
   "slug": "cozy-photos-v3",
-  "icon": "app-icon.svg",
+  "icon": "public/app-icon.svg",
   "description": "Photos manager for Cozy v3",
   "source": "https://github.com/cozy/cozy-photos-v3.git@build",
   "editor": "Cozy",


### PR DESCRIPTION
Regarding https://github.com/cozy/cozy-stack/pull/599#issuecomment-301519778 we moved the app icon to the `public/` folder