### PR TITLE
fix: modal size and display issues

### DIFF
--- a/src/ducks/upload/styles.styl
+++ b/src/ducks/upload/styles.styl
@@ -7,6 +7,7 @@
     right    em(24px)
     height   em(210px)
     width    em(480px)
+    max-width 90%
     border   1px solid grey-09
     border-radius    4px
     background-color white
@@ -15,7 +16,7 @@
     transition       0.5s
     opacity          0
     visibility       hidden
-    transform        translate(300px)
+    transform        translateY(300px)
 
 .upload-queue--visible
     opacity    1

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -1,27 +1,28 @@
 <!DOCTYPE html>
 <html lang="{{.Locale}}">
-<meta charset="utf-8">
-<title><%= htmlWebpackPlugin.options.title %></title>
-<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
-<link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
-<link rel="manifest" href="/manifest.json">
-<meta name="theme-color" content="#ffffff">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
-  <link rel="stylesheet" href="<%- file %>">
-<% }); %>
-<script src="//{{.Domain}}/assets/js/piwik.js" defer></script>
-<% _.forEach(htmlWebpackPlugin.files.js, function(file) {
-    if (!/public\//.test(file)) {
-%>
-  <script src="<%- file %>" defer></script>
-<%  } %>
-<% }); %>
-<% if (__STACK_ASSETS__) { %>
-{{.CozyClientJS}}
-{{.CozyBar}}
-<% } %>
+<head>
+  <meta charset="utf-8">
+  <title><%= htmlWebpackPlugin.options.title %></title>
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
+  <link rel="manifest" href="/manifest.json">
+  <meta name="theme-color" content="#ffffff">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <% _.forEach(htmlWebpackPlugin.files.css, function(file) { %>
+    <link rel="stylesheet" href="<%- file %>">
+  <% }); %>
+  <script src="//{{.Domain}}/assets/js/piwik.js" defer></script>
+  <% _.forEach(htmlWebpackPlugin.files.js, function(file) {
+      if (!/public\//.test(file)) {
+  %>
+    <script src="<%- file %>" defer></script>
+  <%  } %>
+  <% }); %>
+  <% if (__STACK_ASSETS__) { %>
+  {{.CozyClientJS}}
+  {{.CozyBar}}
+  <% } %>
 </head>
 <div
   role="application"

--- a/src/styles/addToAlbum.styl
+++ b/src/styles/addToAlbum.styl
@@ -5,6 +5,7 @@
 
     // Should be in Cozy-uy you know
     .coz-modal-section
+        width       440px
         border-top 1px solid grey-09
         padding    1em 1.5em .5em !important
 


### PR DESCRIPTION
Initial goal: the add-to-album modal now has a default width that matches the mockups.

Side quest: on chrome, in the responsive view, in *some* resolutions, the whole app was behaving very strangely. It was possible to scroll past the actual app both horizontally and vertically, to zoom out of the default view, and the selection bar was in the wrong place.
Turns out the hidden upload queue was causing all of this (although I think that might be a bug in chrome). Applying the translation only on the y axis solves this, and giving the queue a max width makes sure it doesn't go outside the frame on mobile.
Small fix, but it took me forever to find the issue!