### PR TITLE
fix: Add to album modal css fixes

### DIFF
--- a/src/styles/addToAlbum.styl
+++ b/src/styles/addToAlbum.styl
@@ -5,7 +5,9 @@
 
     // Should be in Cozy-uy you know
     .coz-modal-section
+        box-sizing border-box
         width       440px
+        max-width 100%
         border-top 1px solid grey-09
         padding    1em 1.5em .5em !important
 

--- a/src/styles/addToAlbum.styl
+++ b/src/styles/addToAlbum.styl
@@ -9,7 +9,7 @@
         width       440px
         max-width 100%
         border-top 1px solid grey-09
-        padding    1em 1.5em .5em !important
+        padding    1em 1.5em 1.5em !important
 
     .coz-select-album
         height 20em

--- a/src/styles/addToAlbum.styl
+++ b/src/styles/addToAlbum.styl
@@ -8,9 +8,14 @@
         box-sizing border-box
         width       440px
         max-width 100%
+        padding 1em 0 !important
+
+    .coz-create-album
+        padding 1em 1.5em
         border-top 1px solid grey-09
-        padding    1em 1.5em 1.5em !important
 
     .coz-select-album
-        height 20em
+        height 17em
+        padding 1em 1.5em
         overflow auto
+        border-top 1px solid grey-09

--- a/src/styles/albumsList.styl
+++ b/src/styles/albumsList.styl
@@ -20,6 +20,7 @@
     .pho-album-photo-item
         height 4em
         width 4em
+        min-width 4em // solves a rendering bug in chrome
         margin-right 1em
     .pho-album-title
         font-weight normal

--- a/src/styles/createAlbumForm.styl
+++ b/src/styles/createAlbumForm.styl
@@ -18,6 +18,7 @@
         width       100%
 
         .coz-input-text
+            width        40%
             flex-grow    1
 
         .coz-input-text,
@@ -33,3 +34,8 @@
 
             &[aria-busy=true]
                 padding-right 1em
+
+@media (max-width: (1023/basefont)rem)
+    .pho-create-album-form .coz-inline-form .coz-btn
+        padding-left 1.5em
+        padding-right 1.5em


### PR DESCRIPTION
This PR fixes several problems with the add-to-album modal:

- The paddings, which probably conflicts with #97 and may need another update after the latest cozy-ui lands
- SIzing issues on mobile
- A thumbnail-rendering bug in chrome
- Missing borders