### PR TITLE
fix: scrolling bottom on Chrome mobile was funky

### DIFF
--- a/src/ducks/upload/styles.styl
+++ b/src/ducks/upload/styles.styl
@@ -2,7 +2,7 @@
 
 .upload-queue
     @extend $popover
-    position absolute
+    position fixed
     bottom   em(8px)
     right    em(24px)
     height   em(210px)


### PR DESCRIPTION
I guess, in a way, in Chrome's mind, its behaviour made sense.
Anyway, this should fix the bug.