### PR TITLE
fix: horizontal scrolling happened because of too large elements

### DIFF
--- a/src/styles/photoList.styl
+++ b/src/styles/photoList.styl
@@ -3,7 +3,9 @@
 :local
 
     .pho-section
-        left-spaced(32px)
+        box-sizing border-box
+        left-padded(32px)
+        right-padded(32px)
         bottom-spaced(2em)
 
     .pho-photo


### PR DESCRIPTION
So `.pho-section` had a left margin which was kind of harmless at first, but when the AutoSizer plugin appeared, it forced the width of this element to the size of the viewport.
Which means viewport's size + margin = larger than the viewport and in that case there's something to scroll horizontally.

So I changed the margin with right & left padding and add a `box-sizing: border-box` so that even if width is calculated by AutoSizer, it renders accordingly. No more scroll. :)