### PR TITLE
fix: full width uploader on all resolutions

### DIFF
--- a/src/ducks/upload/styles.styl
+++ b/src/ducks/upload/styles.styl
@@ -145,6 +145,7 @@ progress.upload-queue-progress::-moz-progress-bar
         position static
         transform none
         z-index $app-index
+        width 100%
         max-width 100%
         height auto
         max-height 0


### PR DESCRIPTION
On some screen resolutions, the uploader didn't take the full with. Merging it right away, just doing the PR for the record (ping @GoOz)