### PR TITLE
fix: update collection name

### DIFF
--- a/src/ducks/sharing/index.js
+++ b/src/ducks/sharing/index.js
@@ -1,6 +1,6 @@
 /* global cozy */
 export const filterSharedDocuments = (ids, doctype) =>
-  findPermSets(ids, doctype).then(sets => sets.map(set => set.attributes.permissions.collection.values[0]))
+  findPermSets(ids, doctype).then(sets => sets.map(set => set.attributes.permissions.albums.values[0]))
 
 export const findPermSet = (id, doctype) =>
   findPermSets([id], doctype).then(sets => sets.length === 0 ? undefined : sets[0])
@@ -12,7 +12,7 @@ export const findPermSet = (id, doctype) =>
 export const findPermSets = (ids, doctype) =>
   cozy.client.fetchJSON('GET', `/permissions/doctype/${doctype}/sharedByLink`)
     .then(sets => sets.filter(set => {
-      const perm = set.attributes.permissions.collection
+      const perm = set.attributes.permissions.albums
       return perm.type === doctype && ids.find(id => perm.values.indexOf(id) !== -1) !== undefined
     }))
 


### PR DESCRIPTION
I don't know why, but it seems the collections name have changed for permission sets.

s/set.attributes.permissions.collection/set.attributes.permissions.albums/

---

Je ne sais pas pourquoi, mais on dirait que le nom des collections a changé pour les jeux de permission.
s/set.attributes.permissions.collection/set.attributes.permissions.albums/

@goldroraf an idea?