### PR TITLE
fix: update timeline store after addition to album

### DIFF
--- a/src/containers/AddToAlbumModal.jsx
+++ b/src/containers/AddToAlbumModal.jsx
@@ -22,6 +22,11 @@ import {
   addToAlbum }
 from '../ducks/albums'
 
+import {
+  refetchSomePhotos
+}
+from '../ducks/timeline'
+
 export class AddToAlbumModal extends Component {
   componentWillMount () {
     this.props.fetchAlbums()
@@ -80,6 +85,9 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   onSubmitNewAlbum: (name, photos) => {
     return dispatch(createAlbum(name, photos))
       .then(() => {
+        return dispatch(refetchSomePhotos(photos))
+      })
+      .then(() => {
         dispatch(closeAddToAlbum())
         Alerter.success('Albums.create.success', {name: name, smart_count: photos.length})
       })
@@ -87,6 +95,9 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   },
   onSubmitSelectedAlbum: (album, photos) => {
     return dispatch(addToAlbum(album, photos))
+      .then(() => {
+        return dispatch(refetchSomePhotos(photos))
+      })
       .then(() => {
         dispatch(closeAddToAlbum())
         Alerter.success('Albums.add_photos.success', {name: album.name, smart_count: photos.length})

--- a/src/ducks/timeline/index.js
+++ b/src/ducks/timeline/index.js
@@ -98,15 +98,14 @@ export const fetchMorePhotos = createFetchAction(TIMELINE, fetchPhotos)
 * Updates a collection of photos based on their id
 */
 export const refetchSomePhotos = createUpdateAction(TIMELINE, async (photos) => {
-  let index = await indexFilesByDate()
-  let selector = {
+  const index = await indexFilesByDate()
+  const selector = {
     ...DEFAULT_COUCH_SELECTOR,
     '_id': {
       '$in': photos
     }
   }
-  let response = await fetchPhotos(index, 0, selector)
-  return response
+  return await fetchPhotos(index, 0, selector)
 })
 
 export const getPhotosByMonth = (photos, f, format) => {

--- a/src/ducks/timeline/index.js
+++ b/src/ducks/timeline/index.js
@@ -1,5 +1,5 @@
 /* global cozy */
-import { getList, createFetchAction, createFetchIfNeededAction, insertAction, deleteAction } from '../lists'
+import { getList, createFetchAction, createFetchIfNeededAction, createUpdateAction, insertAction, deleteAction } from '../lists'
 import Toolbar from './components/Toolbar'
 import DeleteConfirm from './components/DeleteConfirm'
 import { hideSelectionBar, getSelectedIds } from '../selection'
@@ -7,6 +7,10 @@ import { FILE_DOCTYPE, FETCH_LIMIT, ALBUM_DOCTYPE } from '../../constants/config
 
 // constants
 const TIMELINE = 'timeline'
+const NOT_TRASHED_SELECTOR = {
+  class: 'image',
+  trashed: false
+}
 
 // selectors
 export const getTimelineList = state => getList(state, TIMELINE)
@@ -63,12 +67,9 @@ const indexFilesByDate = async () => {
   return await cozy.client.data.defineIndex(FILE_DOCTYPE, fields)
 }
 
-const fetchPhotos = async (index, skip = 0) => {
+const fetchPhotos = async (index, skip = 0, selector = NOT_TRASHED_SELECTOR) => {
   const options = {
-    selector: {
-      class: 'image',
-      trashed: false
-    },
+    selector,
     // TODO: type and class should not be necessary, it's just a temp fix for a stack bug
     fields: ['_id', 'dir_id', 'name', 'size', 'updated_at', 'metadata', 'type', 'class'],
     descending: true,
@@ -92,6 +93,21 @@ export const fetchIfNeededPhotos = createFetchIfNeededAction(TIMELINE, (index, s
 })
 
 export const fetchMorePhotos = createFetchAction(TIMELINE, fetchPhotos)
+
+/**
+* Updates a collection of photos based on their id
+*/
+export const refetchSomePhotos = createUpdateAction(TIMELINE, async (photos) => {
+  let index = await indexFilesByDate()
+  let selector = {
+    ...NOT_TRASHED_SELECTOR,
+    '_id': {
+      '$in': photos
+    }
+  }
+  let response = await fetchPhotos(index, 0, selector)
+  return response
+})
 
 export const getPhotosByMonth = (photos, f, format) => {
   let sections = {}

--- a/src/ducks/timeline/index.js
+++ b/src/ducks/timeline/index.js
@@ -7,7 +7,7 @@ import { FILE_DOCTYPE, FETCH_LIMIT, ALBUM_DOCTYPE } from '../../constants/config
 
 // constants
 const TIMELINE = 'timeline'
-const NOT_TRASHED_SELECTOR = {
+const DEFAULT_COUCH_SELECTOR = {
   class: 'image',
   trashed: false
 }
@@ -67,7 +67,7 @@ const indexFilesByDate = async () => {
   return await cozy.client.data.defineIndex(FILE_DOCTYPE, fields)
 }
 
-const fetchPhotos = async (index, skip = 0, selector = NOT_TRASHED_SELECTOR) => {
+const fetchPhotos = async (index, skip = 0, selector = DEFAULT_COUCH_SELECTOR) => {
   const options = {
     selector,
     // TODO: type and class should not be necessary, it's just a temp fix for a stack bug
@@ -100,7 +100,7 @@ export const fetchMorePhotos = createFetchAction(TIMELINE, fetchPhotos)
 export const refetchSomePhotos = createUpdateAction(TIMELINE, async (photos) => {
   let index = await indexFilesByDate()
   let selector = {
-    ...NOT_TRASHED_SELECTOR,
+    ...DEFAULT_COUCH_SELECTOR,
     '_id': {
       '$in': photos
     }


### PR DESCRIPTION
The root cause is that after adding a photo to an album, it's references in the store become outdated. I've added a call that re-fetches the photos after they've been added so the store stays correct at all time.
The downside is that this needs to be done whenever an album changes, which currently only happens in `AddToAlbumModal`, but that's bound to change. @goldoraf since you're working on this, I'm curious to hear what you think.