### PR TITLE
fix: share album needs this selector

### DIFF
--- a/src/ducks/sharing/index.js
+++ b/src/ducks/sharing/index.js
@@ -59,7 +59,8 @@ export const share = async ({_id, _type, name}, email, url) => {
         type: 'io.cozy.files',
         values: [
           `io.cozy.photos.albums/${_id}`
-        ]
+        ],
+        selector: 'referenced_by'
       }
     },
     recipients: [


### PR DESCRIPTION
It seems without this property, the sharing link is not working.
Do you confirm that @Gara64 ?
/poke @jsilvestre 
/fix #126 