### PR TITLE
fix: pan after pinch

### DIFF
--- a/src/components/Viewer.jsx
+++ b/src/components/Viewer.jsx
@@ -64,6 +64,8 @@ export class Viewer extends Component {
     // During a gesture, everything is computed with a base value (the state of the image when the gesture starts) and a delta (a translation / zoom, described by the gesture). When a gesture starts, we record the current state of the image.
     this.gesturesHandler.on('panstart', this.prepareForGesture.bind(this))
     this.gesturesHandler.on('pinchstart', this.prepareForGesture.bind(this))
+    // It frequently happens that at the end of a pinch gesture, a pan gesture is detected — because the fingers don't come off the screen at exactly the same time. Reseting the values at the end of the pinch makes sure the values are correct for the (accidental) pan event.
+    this.gesturesHandler.on('pinchend', this.prepareForGesture.bind(this))
 
     // during a pan, we add the gestures delta to the initial offset to get the new offset. The new offset is then scaled : if the pan distance was 100px, but the image was scaled 2x, the actual offset should only be 50px. FInally, this value is clamped to make sure the user can't pan further than the edges.
     this.gesturesHandler.on('pan', e => {


### PR DESCRIPTION
Here's a play by play of what was happening:

1. a pinch start is detected, the base values are computed
1. user does the pinching, everything is fine
1. user removes *one* finger from the pinch —— the pinch gesture ends here, everything is still correct
1. as the user removes the second finger a fraction of a second later, he/she moves a tiny bit
1. this produces a pan event —— but no pan start, because the finger was already there
1. the pan event is computed using the values set in step 1, which are now wrong

The fix makes sure the base values are re-calculated between steps 3 and 4.