### PR TITLE
fix: photo loading indicator

### DIFF
--- a/src/components/Viewer.jsx
+++ b/src/components/Viewer.jsx
@@ -260,7 +260,8 @@ export class Viewer extends Component {
   render () {
     const { isImageLoading, previousID, nextID, currentPhoto, singlePhoto, hideToolbar, scale, offsetX, offsetY } = this.state
     const style = {
-      transform: `scale(${scale}) translate(${offsetX}px, ${offsetY}px)`
+      transform: `scale(${scale}) translate(${offsetX}px, ${offsetY}px)`,
+      display: isImageLoading ? 'none' : 'initial'
     }
     return (
       <div className={styles['pho-viewer-wrapper']} role='viewer' ref={viewer => { this.viewer = viewer }}>


### PR DESCRIPTION
Before: in the photo viewer, when changing photo, the old photo stayed and the loading indicator was next to it.
Now: the old photo disappears, there's only the loading indicator until the new photo is loaded