### PR TITLE
fix: firefox viewer overflow height

### DIFF
--- a/src/styles/viewer.styl
+++ b/src/styles/viewer.styl
@@ -26,6 +26,7 @@
     display         flex
     flex-direction  row
     flex-grow       1
+    overflow        hidden
 
 
 .pho-viewer-nav-previous, .pho-viewer-nav-next
@@ -50,6 +51,7 @@
     position        relative
     display         flex
     flex-grow       1
+    max-height      100%
     justify-content center
     align-items     center
 


### PR DESCRIPTION
In firefox, the photos are bigger than the page, at least on some screen sizes. Because of nested flexboxes, the the image tag was allowed to be bigger than it's parents. The proposed fix forces a max height again.