### PR TITLE
fix: permissions to share albums

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -49,7 +49,7 @@
     "contacts": {
       "description": "Required to to share photos with your contacts",
       "type": "io.cozy.contacts",
-      "methods": ["GET"]
+      "methods": ["GET", "POST"]
     },
     "settings": {
       "description": "Required by the cozy-bar to display Claudy and know which applications are coming soon",

--- a/src/ducks/sharing/index.js
+++ b/src/ducks/sharing/index.js
@@ -77,7 +77,7 @@ export const share = async ({_id, _type, name}, email, url) => {
       {
         recipient: {
           id: target._id,
-          type: 'io.cozy.recipients'
+          type: 'io.cozy.contacts'
         }
       }
     ],


### PR DESCRIPTION
This fixes an important bug that prevents users to share albums with others.