### PR TITLE
feat: add download photos action in selection bar

### DIFF
--- a/src/containers/SelectionBarWithActions.jsx
+++ b/src/containers/SelectionBarWithActions.jsx
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router'
 import { translate } from 'cozy-ui/react/I18n'
 
 import { openAddToAlbum, removeFromAlbum } from '../ducks/albums'
-import { SelectionBar, hideSelectionBar } from '../ducks/selection'
+import { SelectionBar, hideSelectionBar, downloadSelection } from '../ducks/selection'
 import { DeleteConfirm, deletePhotos } from '../ducks/timeline'
 import Alerter from '../components/Alerter'
 import confirm from '../lib/confirm'
@@ -13,6 +13,9 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   actions: {
     'album-add': {
       action: selected => dispatch(openAddToAlbum(selected))
+    },
+    'download': {
+      action: selected => downloadSelection(selected)
     },
     'delete': {
       action: selected => confirm(<DeleteConfirm t={ownProps.t} count={selected.length} related={ownProps.related} />,

--- a/src/ducks/selection/index.js
+++ b/src/ducks/selection/index.js
@@ -1,4 +1,5 @@
 import { combineReducers } from 'redux'
+import { downloadArchive } from '../../lib/redux-cozy-api'
 import SelectionBar from './SelectionBar'
 
 // constants
@@ -21,6 +22,7 @@ export const toggleSelectionBar = () => ({ type: TOGGLE_SELECTION_BAR })
 export const toggleItemSelection = (item, selected) => ({ type: selected ? UNSELECT_ITEM : SELECT_ITEM, id: item.id })
 export const addToSelection = (ids) => ({ type: ADD_TO_SELECTION, ids })
 export const removeFromSelection = (ids) => ({ type: REMOVE_FROM_SELECTION, ids })
+export const downloadSelection = (selected) => downloadArchive('selection', selected)
 
 // components
 export { SelectionBar }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -64,6 +64,7 @@
     "delete": "Delete",
     "album-add": "Add to album",
     "album-remove": "Remove from album",
+    "download": "Download",
     "close": "Close"
   },
   "Albums": {


### PR DESCRIPTION
Added an action in the selection bar enabling the download of photos.
For now, whether it's one or more photos, it generates a zip archive. 
It should be for 2 or more but since a refactoring is ongoing on Photos that would significantly make it easier to directly download one photo, I propose that we deal with it after that refactoring in another PR.