### PR TITLE
feat: Add action in viewer toolbar to download photo

### DIFF
--- a/src/components/Viewer.jsx
+++ b/src/components/Viewer.jsx
@@ -265,7 +265,7 @@ export class Viewer extends Component {
     }
     return (
       <div className={styles['pho-viewer-wrapper']} role='viewer' ref={viewer => { this.viewer = viewer }}>
-        <ViewerToolbar hidden={hideToolbar} />
+        <ViewerToolbar hidden={hideToolbar} currentPhoto={currentPhoto} />
         <div className={styles['pho-viewer-content']}>
           {!singlePhoto && <a role='button' className={styles['pho-viewer-nav-previous']} onClick={() => this.navigateToPhoto(previousID)} />}
           <div className={styles['pho-viewer-photo']}>

--- a/src/components/ViewerToolbar.jsx
+++ b/src/components/ViewerToolbar.jsx
@@ -4,8 +4,9 @@ import classNames from 'classnames'
 import React from 'react'
 import { translate } from 'cozy-ui/react/I18n'
 import { withRouter } from 'react-router'
+import { downloadFile } from '../lib/redux-cozy-api.js'
 
-export const ViewerToolbar = ({ t, router, hidden }) => {
+export const ViewerToolbar = ({ t, router, hidden, currentPhoto }) => {
   const closeViewer = () => {
     // go to parent
     let url = router.location.pathname
@@ -16,7 +17,14 @@ export const ViewerToolbar = ({ t, router, hidden }) => {
   }
   return (
     <div className={classNames(styles['pho-viewer-toolbar'], {[styles['--hidden']]: hidden})} role='viewer-toolbar'>
-      <div className={styles['pho-viewer-toolbar-actions']} />
+      <div className={classNames(styles['coz-selectionbar'], styles['pho-viewer-toolbar-actions'])}>
+        <button
+          className={styles['coz-action-download']}
+          onClick={() => downloadFile(currentPhoto)}
+          >
+          {t('Viewer.actions.download')}
+        </button>
+      </div>
       <div
         className={styles['pho-viewer-toolbar-close']}
         onClick={closeViewer}

--- a/src/lib/redux-cozy-api.js
+++ b/src/lib/redux-cozy-api.js
@@ -286,6 +286,13 @@ export const downloadArchive = async (notSecureFilename, fileIds) => {
   forceFileDownload(fullpath, filename + '.zip')
 }
 
+export const downloadFile = async (file) => {
+  const response = await cozy.client.files.downloadById(file.id)
+  const blob = await response.blob()
+  const filename = file.name
+  forceFileDownload(window.URL.createObjectURL(blob), filename)
+}
+
 // TODO: for this helper, sadly, we need to make it an action creator
 // because we need the store's state in order to retrieve the mango index
 // that's another proof that indexes should be managed by cozy-client-js...

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -155,7 +155,10 @@
     }
   },
   "Viewer": {
-    "close": "Close"
+    "close": "Close",
+    "actions": {
+      "download" : "Download"
+    }
   },
   "destroyconfirmation": {
     "title": "Permanently delete this album?",

--- a/src/styles/viewerToolbar.styl
+++ b/src/styles/viewerToolbar.styl
@@ -1,5 +1,7 @@
 @require 'cozy-ui'
 
+:local
+    @extend $selectionbar
 
 .pho-viewer-toolbar
     z-index     101
@@ -8,26 +10,29 @@
     width       100vw
     height      em(90px)
 
-    &::before
-        content     ''
-        flex-grow   0
-        width       10em
-        font-size   em(14px)
-
 
 .pho-viewer-toolbar-actions
-    display flex
-    width   100%
+    position          static
+    z-index           0
+    display           flex
+    align-items       center
+    justify-content   center
+    width             100%
+    height            auto
+    background-color  transparent
 
 
 .pho-viewer-toolbar-close
-    display         flex
-    flex-grow       0
-    align-items     center
-    width           4.5em
-    cursor          pointer
-    font-weight     bold
-    text-transform  uppercase
+    position         fixed
+    z-index          1
+    top              0
+    right            0
+    display          flex
+    align-items      center
+    justify-content  center
+    width            em(90px)
+    height           em(90px)
+    cursor           pointer
 
 
 .pho-viewer-toolbar-close-cross
@@ -68,7 +73,8 @@
             opacity 0
 
     .pho-viewer-toolbar-close
-        width em(48/14)
+        width   em(48px)
+        height  em(48px)
 
     .pho-viewer-toolbar-close-text
         display none


### PR DESCRIPTION
Added a toolbar action in the Photo viewer so you can now download the photo currently displayed.

![](https://dl.dropboxusercontent.com/u/6801063/captures/viewerDownloadDesk.png)

![](https://dl.dropboxusercontent.com/u/6801063/captures/viewerDownloadMob.png)

Don't know if it's the best way to do it but hey, that's what reviewers are for. 😄 