### PR TITLE
fix: clear selection on view change

### DIFF
--- a/src/containers/AlbumPhotos.jsx
+++ b/src/containers/AlbumPhotos.jsx
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router'
 import styles from '../styles/layout'
 
 import { AlbumToolbar, fetchAlbum, fetchAlbumPhotos, updateAlbum } from '../ducks/albums'
+import { hideSelectionBar } from '../ducks/selection'
 
 import BoardView from './BoardView'
 import Topbar from '../components/Topbar'
@@ -72,6 +73,10 @@ export class AlbumPhotos extends Component {
       photos: this.props.photos.data
     }))
   }
+
+  componentWillUnmount () {
+    this.props.clearSelection()
+  }
 }
 
 const mapDocumentsToProps = (ownProps) => ({
@@ -81,7 +86,8 @@ const mapDocumentsToProps = (ownProps) => ({
 })
 
 export const mapDispatchToProps = (dispatch, ownProps) => ({
-  updateAlbum: (album) => dispatch(updateAlbum(album))
+  updateAlbum: (album) => dispatch(updateAlbum(album)),
+  clearSelection: () => dispatch(hideSelectionBar())
 })
 
 export default cozyConnect(

--- a/src/containers/Timeline.jsx
+++ b/src/containers/Timeline.jsx
@@ -3,6 +3,7 @@ import { cozyConnect } from '../lib/redux-cozy-client'
 import styles from '../styles/layout'
 
 import { Toolbar as TimelineToolbar, fetchTimeline, getPhotosByMonth } from '../ducks/timeline'
+import { hideSelectionBar } from '../ducks/selection'
 
 import BoardView from './BoardView'
 import Topbar from '../components/Topbar'
@@ -35,8 +36,15 @@ export class Timeline extends Component {
       photos: this.props.photos.data
     }))
   }
+
+  componentWillUnmount () {
+    this.props.clearSelection()
+  }
 }
 
 const mapDocumentsToProps = (ownProps) => ({ photos: fetchTimeline() })
+const mapActionsToProps = (dispatch) => ({
+  clearSelection: () => dispatch(hideSelectionBar())
+})
 
-export default cozyConnect(mapDocumentsToProps)(Timeline)
+export default cozyConnect(mapDocumentsToProps, mapActionsToProps)(Timeline)


### PR DESCRIPTION
When switching between the timeline and albums view, the selection is kept, because the state is never changed. This PR clears the selection when the user leaves the view.