### PR TITLE
fix: add download album button on public page for mobile

### DIFF
--- a/src/public/App.jsx
+++ b/src/public/App.jsx
@@ -4,6 +4,7 @@ import { cozyConnect } from '../lib/redux-cozy-client'
 import PhotoBoard from '../components/PhotoBoard'
 import Loading from '../components/Loading'
 import ErrorComponent from '../components/ErrorComponent'
+import Menu, { Item } from '../components/Menu'
 
 import { fetchAlbum, fetchAlbumPhotos, downloadAlbum } from '../ducks/albums'
 
@@ -95,6 +96,20 @@ class App extends Component {
                 {t('Toolbar.album_download')}
               </button>
             </div>
+            <Menu
+              title={t('Toolbar.more')}
+              className={classNames(styles['pho-toolbar-menu'], 'coz-mobile')}
+              buttonClassName={styles['pho-toolbar-more-btn']}
+            >
+              <Item>
+                <a
+                  className={classNames(styles['pho-public-download'])}
+                  onClick={this.onDownload}
+                >
+                  {t('Toolbar.album_download')}
+                </a>
+              </Item>
+            </Menu>
           </div>
         </div>
         <PhotoBoard

--- a/src/public/index.styl
+++ b/src/public/index.styl
@@ -10,7 +10,7 @@
 
 .pho-content-header.--no-icon
     left 0
-    horizontally-padded(15px)
+    left-padded(15px)
 
 .pho-public-download
     padding-left         em(44px, 16px)


### PR DESCRIPTION
Add menu item to download photo in public view when on mobile.

![](https://dl.dropboxusercontent.com/u/6801063/captures/publicDownloadMobile.png)