### PR TITLE
refactor: disable some actions for shared albums

### DIFF
--- a/src/components/AlbumsList.jsx
+++ b/src/components/AlbumsList.jsx
@@ -8,7 +8,7 @@ import AlbumItem from '../containers/AlbumItem'
 const DumbAlbumsList = props => (
   <div className={styles['pho-album-list']}>
     {props.albums.map((a) =>
-      <AlbumItem album={a} sharedByMe={props.sharedByMe.indexOf(a._id) !== -1} sharedWithMe={props.sharedWithMe.indexOf(a._id) !== -1} key={a._id} onServerError={props.onServerError} />)}
+      <AlbumItem album={a} sharedByMe={props.sharedByMe.indexOf(a.id) !== -1} sharedWithMe={props.sharedWithMe.indexOf(a.id) !== -1} key={a.id} onServerError={props.onServerError} />)}
   </div>
 )
 

--- a/src/components/SelectAlbumsForm.jsx
+++ b/src/components/SelectAlbumsForm.jsx
@@ -10,7 +10,7 @@ import AlbumItem from '../containers/AlbumItem'
 
 const DumbAlbumsList = props => (
   <div className={classNames(styles['pho-album-list'], styles['pho-album-list--thumbnails'], styles['pho-album-list--selectable'])}>
-    {props.albums.data.map((a) => <AlbumItem album={a} key={a._id} onServerError={props.onServerError} onClick={props.onSubmitSelectedAlbum} />)}
+    {props.albums.data.map((a) => <AlbumItem album={a} key={a.id} onServerError={props.onServerError} onClick={props.onSubmitSelectedAlbum} disabled={props.readOnly.indexOf(a.id) > -1} />)}
   </div>
 )
 

--- a/src/components/SelectAlbumsForm.jsx
+++ b/src/components/SelectAlbumsForm.jsx
@@ -10,7 +10,7 @@ import AlbumItem from '../containers/AlbumItem'
 
 const DumbAlbumsList = props => (
   <div className={classNames(styles['pho-album-list'], styles['pho-album-list--thumbnails'], styles['pho-album-list--selectable'])}>
-    {props.albums.data.map((a) => <AlbumItem album={a} key={a.id} onServerError={props.onServerError} onClick={props.onSubmitSelectedAlbum} disabled={props.readOnly.indexOf(a.id) > -1} />)}
+    {props.albums.data.map((a) => <AlbumItem album={a} key={a.id} sharedWithMe={props.sharedWithMe.indexOf(a.id) !== -1} onServerError={props.onServerError} onClick={props.onSubmitSelectedAlbum} disabled={props.sharedWithMe.indexOf(a.id) !== -1} />)}
   </div>
 )
 

--- a/src/containers/AddToAlbumModal.jsx
+++ b/src/containers/AddToAlbumModal.jsx
@@ -12,6 +12,7 @@ import SelectAlbumsForm from '../components/SelectAlbumsForm'
 import Loading from '../components/Loading'
 
 import { getSelectedIds } from '../ducks/selection'
+import { withSharings, SHARED_WITH_ME } from '../ducks/sharing'
 
 import {
   fetchAlbums,
@@ -68,7 +69,7 @@ export class AddToAlbumModal extends Component {
   }
 
   render () {
-    const { t, photos, albums } = this.props
+    const { t, photos, albums, sharedWithMe } = this.props
 
     const fetchStatus = albums ? albums.fetchStatus : 'loading'
     const isFetchingAlbums = fetchStatus === 'pending' || fetchStatus === 'loading'
@@ -89,7 +90,7 @@ export class AddToAlbumModal extends Component {
             ? <Loading loadingType='albums_fetching' />
             : albums && albums.data.length > 0
             ? <div className={classNames(styles['coz-select-album'])}>
-              <SelectAlbumsForm albums={albums} onSubmitSelectedAlbum={album => this.onSubmitSelectedAlbum(album, photos)} />
+              <SelectAlbumsForm albums={albums} readOnly={sharedWithMe} onSubmitSelectedAlbum={album => this.onSubmitSelectedAlbum(album, photos)} />
             </div>
             : null
           }
@@ -102,4 +103,4 @@ export class AddToAlbumModal extends Component {
 const mapDocumentsToProps = (ownProps) => ({ albums: fetchAlbums() })
 const mapStateToProps = (state, ownProps) => ({ photos: getSelectedIds(state) })
 
-export default connect(mapStateToProps)(cozyConnect(mapDocumentsToProps)(AddToAlbumModal))
+export default connect(mapStateToProps)(cozyConnect(mapDocumentsToProps)(withSharings(AddToAlbumModal, 'albums', 'io.cozy.photos.albums', [SHARED_WITH_ME])))

--- a/src/containers/AddToAlbumModal.jsx
+++ b/src/containers/AddToAlbumModal.jsx
@@ -90,7 +90,7 @@ export class AddToAlbumModal extends Component {
             ? <Loading loadingType='albums_fetching' />
             : albums && albums.data.length > 0
             ? <div className={classNames(styles['coz-select-album'])}>
-              <SelectAlbumsForm albums={albums} readOnly={sharedWithMe} onSubmitSelectedAlbum={album => this.onSubmitSelectedAlbum(album, photos)} />
+              <SelectAlbumsForm albums={albums} sharedWithMe={sharedWithMe} onSubmitSelectedAlbum={album => this.onSubmitSelectedAlbum(album, photos)} />
             </div>
             : null
           }

--- a/src/containers/AlbumItem.jsx
+++ b/src/containers/AlbumItem.jsx
@@ -25,18 +25,15 @@ const AlbumItemLink = ({ router, album, image, title, desc }) => {
 }
 const LinkedAlbumItem = withRouter(AlbumItemLink)
 
-const ClickableAlbumItem = ({ album, image, title, desc, disabled }) => {
+const ClickableAlbumItem = ({ album, image, title, desc, onClick, disabled }) => {
   return disabled
-  ?
-  <div className={classNames(styles['pho-album-link'], styles['pho-album-link--disabled'])}>
+  ? <div className={classNames(styles['pho-album-link'], styles['pho-album-link--disabled'])}>
     {image}{title}{desc}
   </div>
-  :
-  <div onClick={() => onClick(album)} className={styles['pho-album-link']}>
+  : <div onClick={() => onClick(album)} className={styles['pho-album-link']}>
     {image}{title}{desc}
   </div>
 }
-
 
 export class AlbumItem extends Component {
   render () {
@@ -70,10 +67,8 @@ export class AlbumItem extends Component {
       <div className={styles['pho-album']}>
         {
           onClick
-          ?
-          <ClickableAlbumItem album={album} image={image} title={title} desc={desc} disabled={disabled} />
-          :
-          <LinkedAlbumItem album={album} image={image} title={title} desc={desc} />
+          ? <ClickableAlbumItem album={album} image={image} title={title} desc={desc} onClick={onClick} disabled={disabled} />
+          : <LinkedAlbumItem album={album} image={image} title={title} desc={desc} />
         }
         {(sharedByMe || sharedWithMe) && <SharedIcon byMe={sharedByMe} />}
       </div>

--- a/src/containers/AlbumItem.jsx
+++ b/src/containers/AlbumItem.jsx
@@ -15,14 +15,37 @@ const SharedIcon = ({ byMe }) => (
   </div>
 )
 
+const AlbumItemLink = ({ router, album, image, title, desc }) => {
+  const parentPath = router.location.pathname
+  return (
+    <Link to={`${parentPath}/${album._id}`} className={styles['pho-album-link']}>
+      {image}{title}{desc}
+    </Link>
+  )
+}
+const LinkedAlbumItem = withRouter(AlbumItemLink)
+
+const ClickableAlbumItem = ({ album, image, title, desc, disabled }) => {
+  return disabled
+  ?
+  <div className={classNames(styles['pho-album-link'], styles['pho-album-link--disabled'])}>
+    {image}{title}{desc}
+  </div>
+  :
+  <div onClick={() => onClick(album)} className={styles['pho-album-link']}>
+    {image}{title}{desc}
+  </div>
+}
+
+
 export class AlbumItem extends Component {
   render () {
-    const { t, album, photos, sharedByMe, sharedWithMe, onClick } = this.props
+    const { t, album, photos, sharedByMe, sharedWithMe, onClick, disabled } = this.props
     if (photos.fetchStatus !== 'loaded') {
       return null
     }
-    const coverPhoto = photos.data[0] || null
 
+    const coverPhoto = photos.data[0] || null
     const image = !coverPhoto
       ? <div
         className={styles['pho-album-photo-item']}
@@ -33,30 +56,25 @@ export class AlbumItem extends Component {
         photo={coverPhoto}
         src={`${cozy.client._url}${coverPhoto.links.small}`}
       />
+
     const desc = <h4 className={styles['pho-album-description']}>
       {t('Albums.album_item_description',
         {smart_count: photos.count})
       }
       {(sharedByMe || sharedWithMe) && ` - ${t('Albums.album_item_shared_ro')}`}
     </h4>
+
     const title = <h2 className={styles['pho-album-title']}>{album.name}</h2>
 
-    if (onClick) {
-      return (
-        <div className={styles['pho-album']}>
-          <div onClick={() => onClick(album)} className={styles['pho-album-link']}>
-            {image}{title}{desc}
-          </div>
-          {(sharedByMe || sharedWithMe) && <SharedIcon byMe={false} />}
-        </div>
-      )
-    }
-    const parentPath = this.props.router.location.pathname
     return (
       <div className={styles['pho-album']}>
-        <Link to={`${parentPath}/${album._id}`} className={styles['pho-album-link']}>
-          {image}{title}{desc}
-        </Link>
+        {
+          onClick
+          ?
+          <ClickableAlbumItem album={album} image={image} title={title} desc={desc} disabled={disabled} />
+          :
+          <LinkedAlbumItem album={album} image={image} title={title} desc={desc} />
+        }
         {(sharedByMe || sharedWithMe) && <SharedIcon byMe={sharedByMe} />}
       </div>
     )
@@ -67,4 +85,4 @@ const mapDocumentsToProps = (ownProps) => ({
   photos: fetchAlbumPhotos(ownProps.album)
 })
 
-export default withRouter(cozyConnect(mapDocumentsToProps)(AlbumItem))
+export default cozyConnect(mapDocumentsToProps)(AlbumItem)

--- a/src/containers/AlbumItem.jsx
+++ b/src/containers/AlbumItem.jsx
@@ -19,7 +19,9 @@ const AlbumItemLink = ({ router, album, image, title, desc }) => {
   const parentPath = router.location.pathname
   return (
     <Link to={`${parentPath}/${album._id}`} className={styles['pho-album-link']}>
-      {image}{title}{desc}
+      {image}
+      {title}
+      {desc}
     </Link>
   )
 }
@@ -28,10 +30,18 @@ const LinkedAlbumItem = withRouter(AlbumItemLink)
 const ClickableAlbumItem = ({ album, image, title, desc, onClick, disabled }) => {
   return disabled
   ? <div className={classNames(styles['pho-album-link'], styles['pho-album-link--disabled'])}>
-    {image}{title}{desc}
+    {image}
+    <div>
+      {title}
+      {desc}
+    </div>
   </div>
   : <div onClick={() => onClick(album)} className={styles['pho-album-link']}>
-    {image}{title}{desc}
+    {image}
+    <div>
+      {title}
+      {desc}
+    </div>
   </div>
 }
 
@@ -55,6 +65,7 @@ export class AlbumItem extends Component {
       />
 
     const desc = <h4 className={styles['pho-album-description']}>
+      {(sharedByMe || sharedWithMe) && <SharedIcon byMe={sharedByMe} />}
       {t('Albums.album_item_description',
         {smart_count: photos.count})
       }
@@ -70,7 +81,6 @@ export class AlbumItem extends Component {
           ? <ClickableAlbumItem album={album} image={image} title={title} desc={desc} onClick={onClick} disabled={disabled} />
           : <LinkedAlbumItem album={album} image={image} title={title} desc={desc} />
         }
-        {(sharedByMe || sharedWithMe) && <SharedIcon byMe={sharedByMe} />}
       </div>
     )
   }

--- a/src/containers/AlbumPhotos.jsx
+++ b/src/containers/AlbumPhotos.jsx
@@ -51,7 +51,7 @@ export class AlbumPhotos extends Component {
       <div className={styles['pho-content-wrapper']}>
         {(album.name && photos.data) &&
           <Topbar viewName='albumContent' albumName={album.name} editing={editing} onEdit={this.renameAlbum.bind(this)} >
-            <AlbumToolbar album={album} photos={photos.data} onRename={this.editAlbumName.bind(this)} />
+            <AlbumToolbar album={album} readonly={true} photos={photos.data} onRename={this.editAlbumName.bind(this)} />
           </Topbar>
         }
         {photos.data &&

--- a/src/containers/AlbumPhotos.jsx
+++ b/src/containers/AlbumPhotos.jsx
@@ -62,6 +62,7 @@ export class AlbumPhotos extends Component {
             photos={photos}
             photoLists={[{ photos: photos.data }]}
             photosContext='album'
+            readOnly={sharedWithMe.length > 0}
           />
         }
         {this.renderViewer(this.props.children)}

--- a/src/containers/AlbumPhotos.jsx
+++ b/src/containers/AlbumPhotos.jsx
@@ -5,6 +5,7 @@ import styles from '../styles/layout'
 
 import { AlbumToolbar, fetchAlbum, fetchAlbumPhotos, updateAlbum } from '../ducks/albums'
 import { hideSelectionBar } from '../ducks/selection'
+import { withSharings, SHARED_WITH_ME } from '../ducks/sharing'
 
 import BoardView from './BoardView'
 import Topbar from '../components/Topbar'
@@ -45,13 +46,14 @@ export class AlbumPhotos extends Component {
     if (!this.props.album) {
       return null
     }
-    const { album, photos } = this.props
+    const { album, photos, sharedWithMe } = this.props
     const { editing } = this.state
+
     return (
       <div className={styles['pho-content-wrapper']}>
         {(album.name && photos.data) &&
           <Topbar viewName='albumContent' albumName={album.name} editing={editing} onEdit={this.renameAlbum.bind(this)} >
-            <AlbumToolbar album={album} readonly={true} photos={photos.data} onRename={this.editAlbumName.bind(this)} />
+            <AlbumToolbar album={album} readOnly={sharedWithMe.length > 0} photos={photos.data} onRename={this.editAlbumName.bind(this)} />
           </Topbar>
         }
         {photos.data &&
@@ -93,4 +95,4 @@ export const mapDispatchToProps = (dispatch, ownProps) => ({
 export default cozyConnect(
   mapDocumentsToProps,
   mapDispatchToProps
-)(withRouter(AlbumPhotos))
+)(withRouter(withSharings(AlbumPhotos, 'album', 'io.cozy.photos.albums', [SHARED_WITH_ME])))

--- a/src/containers/BoardView.jsx
+++ b/src/containers/BoardView.jsx
@@ -19,6 +19,7 @@ class BoardView extends Component {
     const {
       album,
       related,
+      readOnly,
       selected,
       isAddToAlbumModalOpened,
       onPhotoToggle,
@@ -36,7 +37,7 @@ class BoardView extends Component {
     return (
       <div role='contentinfo'>
         {isAddToAlbumModalOpened && <AddToAlbumModal />}
-        {selectionModeActive && <SelectionBarWithActions album={album} related={related} />}
+        {selectionModeActive && <SelectionBarWithActions album={album} related={related} readOnly={readOnly} />}
         <PhotoBoard
           lists={photoLists}
           selected={selected}

--- a/src/containers/SelectionBarWithActions.jsx
+++ b/src/containers/SelectionBarWithActions.jsx
@@ -13,7 +13,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
   actions: {
     'album-add': {
       action: selected => dispatch(openAddToAlbum(selected)),
-      displayCondition: () => ownProps.album === undefined ? true : (ownProps.album.readonly === false && false)
+      displayCondition: () => ownProps.album === undefined ? true : (ownProps.album.readOnly === false && false)
     },
     'download': {
       action: selected => downloadSelection(selected)

--- a/src/containers/SelectionBarWithActions.jsx
+++ b/src/containers/SelectionBarWithActions.jsx
@@ -12,7 +12,8 @@ import confirm from '../lib/confirm'
 const mapDispatchToProps = (dispatch, ownProps) => ({
   actions: {
     'album-add': {
-      action: selected => dispatch(openAddToAlbum(selected))
+      action: selected => dispatch(openAddToAlbum(selected)),
+      displayCondition: () => ownProps.album === undefined ? true : (ownProps.album.readonly === false && false)
     },
     'download': {
       action: selected => downloadSelection(selected)
@@ -32,7 +33,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
           dispatch(hideSelectionBar())
         })
         .catch(() => Alerter.error('Albums.remove_photos.error.generic')),
-      displayCondition: () => ownProps.album !== undefined
+      displayCondition: () => (ownProps.album === undefined ? false : (ownProps.album.readonly === false && false))
     }
   }
 })

--- a/src/containers/SelectionBarWithActions.jsx
+++ b/src/containers/SelectionBarWithActions.jsx
@@ -12,8 +12,7 @@ import confirm from '../lib/confirm'
 const mapDispatchToProps = (dispatch, ownProps) => ({
   actions: {
     'album-add': {
-      action: selected => dispatch(openAddToAlbum(selected)),
-      displayCondition: () => ownProps.album === undefined ? true : (ownProps.album.readOnly === false && false)
+      action: selected => dispatch(openAddToAlbum(selected))
     },
     'download': {
       action: selected => downloadSelection(selected)
@@ -33,7 +32,7 @@ const mapDispatchToProps = (dispatch, ownProps) => ({
           dispatch(hideSelectionBar())
         })
         .catch(() => Alerter.error('Albums.remove_photos.error.generic')),
-      displayCondition: () => (ownProps.album === undefined ? false : (ownProps.album.readonly === false && false))
+      displayCondition: () => (ownProps.album !== undefined && ownProps.readOnly === false)
     }
   }
 })

--- a/src/ducks/albums/components/AlbumToolbar.jsx
+++ b/src/ducks/albums/components/AlbumToolbar.jsx
@@ -32,13 +32,15 @@ class AlbumToolbar extends Component {
   }
 
   render () {
-    const { t, location, album, photos, readonly, disabled = false, deleteAlbum, selectItems, onRename } = this.props
+    const { t, location, album, photos, readOnly, disabled = false, deleteAlbum, selectItems, onRename } = this.props
     return (
       <div className={styles['pho-toolbar']} role='toolbar'>
         <div className='coz-desktop'>
-          {!readonly && <ShareButton
-            label={t('Albums.share.cta')}
-            onClick={this.showShareModal} />}
+          {!readOnly &&
+            <ShareButton
+              label={t('Albums.share.cta')}
+              onClick={this.showShareModal} />
+          }
         </div>
         <Menu
           title={t('Toolbar.more')}
@@ -46,12 +48,13 @@ class AlbumToolbar extends Component {
           className={styles['pho-toolbar-menu']}
           buttonClassName={styles['pho-toolbar-more-btn']}
         >
-          {!readonly &&
-          <Item>
-            <a className={classNames(styles['pho-action-share'], 'coz-mobile')} onClick={this.showShareModal}>
-              {t('Albums.share.cta')}
-            </a>
-          </Item>}
+          {!readOnly &&
+            <Item>
+              <a className={classNames(styles['pho-action-share'], 'coz-mobile')} onClick={this.showShareModal}>
+                {t('Albums.share.cta')}
+              </a>
+            </Item>
+          }
           <Item>
             <a className={classNames(styles['pho-action-download'])} onClick={() => downloadAlbum(album, photos)}>
               {t('Toolbar.menu.download_album')}
@@ -62,25 +65,27 @@ class AlbumToolbar extends Component {
               {t('Toolbar.menu.rename_album')}
             </a>
           </Item>
-          {!readonly &&
-          <Item>
-            <Link className={classNames(styles['pho-action-addphotos'])} to={`${location.pathname}/edit`}>
-              {t('Toolbar.menu.add_photos')}
-            </Link>
-          </Item>}
+          {!readOnly &&
+            <Item>
+              <Link className={classNames(styles['pho-action-addphotos'])} to={`${location.pathname}/edit`}>
+                {t('Toolbar.menu.add_photos')}
+              </Link>
+            </Item>
+          }
           <hr className='coz-mobile' />
           <Item>
             <a className={classNames(styles['pho-action-select'], 'coz-mobile')} onClick={selectItems}>
               {t('Toolbar.menu.select_items')}
             </a>
           </Item>
-          <hr />
-          {!readonly &&
-          <Item>
-            <a className={classNames(styles['pho-action-delete'])} onClick={() => deleteAlbum(album)}>
-              {t('Toolbar.menu.album_delete')}
-            </a>
-          </Item>}
+          {!readOnly && <hr />}
+          {!readOnly &&
+            <Item>
+              <a className={classNames(styles['pho-action-delete'])} onClick={() => deleteAlbum(album)}>
+                {t('Toolbar.menu.album_delete')}
+              </a>
+            </Item>
+          }
         </Menu>
         {this.state.showShareModal && <ShareModal document={album} onClose={this.closeShareModal} />}
       </div>

--- a/src/ducks/albums/components/AlbumToolbar.jsx
+++ b/src/ducks/albums/components/AlbumToolbar.jsx
@@ -32,13 +32,13 @@ class AlbumToolbar extends Component {
   }
 
   render () {
-    const { t, location, album, photos, disabled = false, deleteAlbum, selectItems, onRename } = this.props
+    const { t, location, album, photos, readonly, disabled = false, deleteAlbum, selectItems, onRename } = this.props
     return (
       <div className={styles['pho-toolbar']} role='toolbar'>
         <div className='coz-desktop'>
-          <ShareButton
+          {!readonly && <ShareButton
             label={t('Albums.share.cta')}
-            onClick={this.showShareModal} />
+            onClick={this.showShareModal} />}
         </div>
         <Menu
           title={t('Toolbar.more')}
@@ -46,11 +46,12 @@ class AlbumToolbar extends Component {
           className={styles['pho-toolbar-menu']}
           buttonClassName={styles['pho-toolbar-more-btn']}
         >
+          {!readonly &&
           <Item>
             <a className={classNames(styles['pho-action-share'], 'coz-mobile')} onClick={this.showShareModal}>
               {t('Albums.share.cta')}
             </a>
-          </Item>
+          </Item>}
           <Item>
             <a className={classNames(styles['pho-action-download'])} onClick={() => downloadAlbum(album, photos)}>
               {t('Toolbar.menu.download_album')}
@@ -61,11 +62,12 @@ class AlbumToolbar extends Component {
               {t('Toolbar.menu.rename_album')}
             </a>
           </Item>
+          {!readonly &&
           <Item>
             <Link className={classNames(styles['pho-action-addphotos'])} to={`${location.pathname}/edit`}>
               {t('Toolbar.menu.add_photos')}
             </Link>
-          </Item>
+          </Item>}
           <hr className='coz-mobile' />
           <Item>
             <a className={classNames(styles['pho-action-select'], 'coz-mobile')} onClick={selectItems}>
@@ -73,11 +75,12 @@ class AlbumToolbar extends Component {
             </a>
           </Item>
           <hr />
+          {!readonly &&
           <Item>
             <a className={classNames(styles['pho-action-delete'])} onClick={() => deleteAlbum(album)}>
               {t('Toolbar.menu.album_delete')}
             </a>
-          </Item>
+          </Item>}
         </Menu>
         {this.state.showShareModal && <ShareModal document={album} onClose={this.closeShareModal} />}
       </div>

--- a/src/ducks/sharing/index.js
+++ b/src/ducks/sharing/index.js
@@ -3,10 +3,10 @@ export const filterSharedByLinkDocuments = (ids, doctype) =>
   fetchShareLinkPermissions(ids, doctype, 'collection').then(sets => sets.map(set => set.attributes.permissions['collection'].values[0]))
 
 export const filterSharedWithMeDocuments = (ids, doctype) =>
-  fetchSharedWithMePermissions(ids, doctype, 'collection').then(sets => sets.map(set => set.attributes.permissions['collection'].values[0]))
+  fetchSharedWithMePermissions(ids, doctype, 'rule0').then(sets => sets.map(set => set.attributes.permissions['rule0'].values[0]))
 
-export const filterSharedWithOthersDocuments = (id, doctype) =>
-  fetchSharedWithOthersPermissions([id], doctype, 'rule0')
+export const filterSharedWithOthersDocuments = (ids, doctype) =>
+  fetchSharedWithOthersPermissions(ids, doctype, 'rule0').then(sets => sets.map(set => set.attributes.permissions['rule0'].values[0]))
 
 // TODO: move this to cozy-client-js
 // there is cozy.client.files.getCollectionShareLink already, but I think that
@@ -53,9 +53,9 @@ export const createShareLink = (id, doctype = 'io.cozy.photos.albums') =>
  * helpers
  */
 
-const SHARED_BY_LINK = 'sharedByLink'
-const SHARED_WITH_ME = 'sharedWithMe'
-const SHARED_WITH_OTHERS = 'sharedWithOthers'
+export const SHARED_BY_LINK = 'sharedByLink'
+export const SHARED_WITH_ME = 'sharedWithMe'
+export const SHARED_WITH_OTHERS = 'sharedWithOthers'
 
 const fetchPermissions = (sharingType) =>
   (ids, doctype, key) =>
@@ -129,7 +129,7 @@ const getProperty = (property, comparator) => (list, id) => {
 const getEmail = getProperty('email', id => item => item._id === id)
 const getUrl = getProperty('url', id => item => item._id === id)
 
-export const getRecipients = (id, type) => filterSharedWithOthersDocuments(id, type)
+export const getRecipients = (id, type) => fetchSharedWithOthersPermissions([id], type, 'rule0')
   .then(perms => perms.map(perm => perm.attributes.source_id))
   .then(fetchSharings)
   .then(sharings =>
@@ -155,5 +155,6 @@ export const getRecipients = (id, type) => filterSharedWithOthersDocuments(id, t
   })
 
 import ShareModal from './ShareModal'
+import withSharings from './withSharings'
 
-export { ShareModal }
+export { ShareModal, withSharings }

--- a/src/ducks/sharing/withSharings.jsx
+++ b/src/ducks/sharing/withSharings.jsx
@@ -8,6 +8,15 @@ import {
   SHARED_WITH_OTHERS
 } from './'
 
+/*
+Injects sharing information for documents that are fetched via cozy-connect.
+It can inject 3 props:
+- sharedByLink
+- sharedWithMe
+- sharedWithOthers
+
+`propName`is the name of the collection provided by cozy-connect, `doctype` is the... uh, doctype, and `sharingTypes` is the list of sharing types that should be injected as props, and they have to be one of the constants `SHARED_BY_LINK`, `SHARED_WITH_ME` or `SHARED_WITH_OTHERS`
+*/
 const withSharings = (WrappedComponent, propName, doctype, sharingTypes = []) => {
   return class extends Component {
     constructor (props) {
@@ -33,15 +42,22 @@ const withSharings = (WrappedComponent, propName, doctype, sharingTypes = []) =>
       } else {
         this.trackSharedWithOthers = false
       }
+
+      this.fetchedIds = []
     }
 
     componentWillReceiveProps (newProps) {
       const propValue = newProps[propName]
 
       if (propValue) {
-        const ids = propValue.ids ? propValue.ids : [propValue.id]
+        // a cozy-connect collection can have a prop named `ids` or `id`, depending on how many documents are being fetched
+        let ids
+        if (propValue.ids) ids = propValue.ids
+        else if (propValue.id) ids = [propValue.id]
+        else ids = []
 
-        if (ids.length === 0) return
+        if (ids.length === 0 || JSON.stringify(ids) === JSON.stringify(this.fetchedIds)) return
+        this.fetchedIds = ids
 
         let filterSharings = []
         if (this.trackSharedByLinks) filterSharings.push(filterSharedByLinkDocuments(ids, doctype))

--- a/src/ducks/sharing/withSharings.jsx
+++ b/src/ducks/sharing/withSharings.jsx
@@ -1,0 +1,69 @@
+import React, { Component } from 'react'
+import {
+  filterSharedByLinkDocuments,
+  filterSharedWithMeDocuments,
+  filterSharedWithOthersDocuments,
+  SHARED_BY_LINK,
+  SHARED_WITH_ME,
+  SHARED_WITH_OTHERS
+} from './'
+
+const withSharings = (WrappedComponent, propName, doctype, sharingTypes = []) => {
+  return class extends Component {
+    constructor (props) {
+      super(props)
+
+      if (sharingTypes.indexOf(SHARED_BY_LINK) > -1) {
+        this.state.sharedByLink = []
+        this.trackSharedByLinks = true
+      } else {
+        this.trackSharedByLinks = false
+      }
+
+      if (sharingTypes.indexOf(SHARED_WITH_ME) > -1) {
+        this.state.sharedWithMe = []
+        this.trackSharedWithMe = true
+      } else {
+        this.trackSharedWithMe = false
+      }
+
+      if (sharingTypes.indexOf(SHARED_WITH_OTHERS) > -1) {
+        this.state.sharedWithOthers = []
+        this.trackSharedWithOthers = true
+      } else {
+        this.trackSharedWithOthers = false
+      }
+    }
+
+    componentWillReceiveProps (newProps) {
+      const propValue = newProps[propName]
+
+      if (propValue) {
+        const ids = propValue.ids ? propValue.ids : [propValue.id]
+
+        if (ids.length === 0) return
+
+        let filterSharings = []
+        if (this.trackSharedByLinks) filterSharings.push(filterSharedByLinkDocuments(ids, doctype))
+        if (this.trackSharedWithMe) filterSharings.push(filterSharedWithMeDocuments(ids, doctype))
+        if (this.trackSharedWithOthers) filterSharings.push(filterSharedWithOthersDocuments(ids, doctype))
+
+        Promise.all(filterSharings)
+        .then(sharedIds => {
+          let updatedState = {}
+          if (this.trackSharedByLinks) updatedState.sharedByLink = sharedIds.shift()
+          if (this.trackSharedWithMe) updatedState.sharedWithMe = sharedIds.shift()
+          if (this.trackSharedWithOthers) updatedState.sharedWithOthers = sharedIds.shift()
+
+          this.setState(updatedState)
+        })
+      }
+    }
+
+    render () {
+      return <WrappedComponent {...this.props} {...this.state} />
+    }
+  }
+}
+
+export default withSharings

--- a/src/styles/albumsList.styl
+++ b/src/styles/albumsList.styl
@@ -31,6 +31,9 @@
 .pho-album-list--selectable
     .pho-album-link
         cursor pointer
+    .pho-album-link--disabled
+        cursor not-allowed
+        opacity .6
 
 .pho-album
     margin      .5em 1em 2em 1em

--- a/src/styles/albumsList.styl
+++ b/src/styles/albumsList.styl
@@ -27,6 +27,15 @@
         color grey-08
     .pho-album-description
         text-align right
+    .pho-album-shared
+        position static
+        display inline-block
+        vertical-align middle
+        margin-right .5em
+
+        .pho-album-shared-icon
+            padding .6em
+            background-size 50%
 
 .pho-album-list--selectable
     .pho-album-link
@@ -69,7 +78,7 @@
 
 .pho-album-shared
     position          absolute
-    top               em(147px)
+    top               em(175px)
     right             em(10px)
     padding           em(2px)
     background-color  white


### PR DESCRIPTION
Albums that are shared with me are read-only, so this PR updates the UI in several places to reflect that.

For the review, start with the `withSharings` HOC, as everything else depends on that. From now on, whenever we display an album, we need to know if it was shared, and how.  I think the correct way to do this would be through cozy-connect and the redux state, however I didn't know how to do that in a reasonable timeframe. 

Instead, I created a HOC that essentially does [this](https://github.com/cozy/cozy-photos-v3/blob/f2c3f7c587b5e4f0224f797084b0c93c932396e1/src/containers/AlbumsView.jsx#L35). It doesn't make the approach better, but at least it's consistent and all in one place, which should make things easier for the next refactoring bit.

All other changes are minor refactorings and UI updates.