### PR TITLE
fix: treat undefined as pending :bug:

### DIFF
--- a/src/ducks/sharing/components/WhoHasAccess.jsx
+++ b/src/ducks/sharing/components/WhoHasAccess.jsx
@@ -24,7 +24,9 @@ class StatefulWhoHasAccess extends React.Component {
       recipients.map(recipient => {
         const status = recipient.status === 'accepted'
          ? t(`Share.status.${recipient.status}.${recipient.type}`)
-         : t(`Share.status.${recipient.status}`)
+         : recipient.status
+           ? t(`Share.status.${recipient.status}`)
+           : t('Share.status.pending')
         return {
           ...recipient,
           status


### PR DESCRIPTION
A tiny hack to treat any `undefined` status as pending (waiting for the status to be defined).