### PR TITLE
fix: use cozy-ui style :nail_care:

### DIFF
--- a/src/ducks/sharing/share.styl
+++ b/src/ducks/sharing/share.styl
@@ -9,6 +9,7 @@
         @extend $form
         @extend $form-text
         @extend $form-button
+        @extend $form-select
         padding 0 1.5em 1.5em
 
     .pho-share-modal-tabs
@@ -38,7 +39,6 @@
 
         .coz-select
             flex 0 0 49%
-            height 40px
 
     input[type=text]
         width 100%


### PR DESCRIPTION
![](https://trello-attachments.s3.amazonaws.com/57da4dfc93887d78762638ef/5948fce348182dc7eccce7a5/5c45877feac693817e919e6d9265bf13/A2oDNDd.png)

As you can see in the screenshot, I spotted two things:

1. The height is not the same as the button
1. We may have a tooling problem when generating CSS