### PR TITLE
fix: select and button the same size

### DIFF
--- a/src/ducks/sharing/share.styl
+++ b/src/ducks/sharing/share.styl
@@ -39,6 +39,8 @@
 
         .coz-select
             flex 0 0 49%
+            height em(40px)
+            padding-bottom em(7px)
 
     input[type=text]
         width 100%


### PR DESCRIPTION
I guess @GoOz will have a better solution for such a problem. But I am not familiar with side-effects on changing something in [cozy-ui](https://github.com/cozy/cozy-ui).

Then, before:

![](https://i.imgur.com/D4e4p2b.png)

and after:

![](https://i.imgur.com/iycdUq5.png)