### PR TITLE
feat: if autocomplete knows the url, use it

### DIFF
--- a/src/ducks/sharing/components/ShareAutocomplete.jsx
+++ b/src/ducks/sharing/components/ShareAutocomplete.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import Autosuggest from 'react-autosuggest'
-import { getContacts } from '..'
+import { getContacts, getEmail, getCozy } from '..'
 
 import autosuggestTheme from './autosuggest.styl'
 
@@ -13,64 +13,48 @@ export default class ShareAutocomplete extends Component {
   }
 
   componentDidMount () {
-    this.fetchContacts()
-  }
-
-  async fetchContacts () {
-    const contacts = await getContacts()
-    this.setState({ contacts })
-  }
-
-  getPrimaryEmailAddress (contact) {
-    // look for an address marked as primary, fallback to the first one or to an empty string
-    if (contact.email.length === 0) return ''
-
-    let primary = contact.email.find(email => email.primary)
-    return primary ? primary.address : contact.email[0].address
-  }
-
-  getPrimaryCozyUrl (contact) {
-    // same thing as getPrimaryEmailAddress
-    if (!contact.cozy || contact.cozy.length === 0) return ''
-
-    let primary = contact.cozy.find(cozy => cozy.primary)
-    return primary ? primary.url : contact.cozy[0].url
+    getContacts().then((contacts) => {
+      this.setState(state => ({ ...state, contacts }))
+    })
   }
 
   computeSuggestions (value) {
-    // Looks into all email addressses and tries to find one that starts with the current input value.
-    // Note that it might find a match on an address taht is not considered primary.
     const inputValue = value.trim().toLowerCase()
-    const inputLength = inputValue.length
-
-    return inputLength === 0 ? [] : this.state.contacts.filter(contact => {
-      if (!contact.email) return false
-      // technically `email` is supposed to be an array, but we can handle a single value here
-      if (contact.email instanceof Array === false) contact.email = [{address: contact.email.toString()}]
-
-      return contact.email.filter(email => (email.address.toLowerCase().slice(0, inputLength) === inputValue)).length > 0
-    })
+    return inputValue.length === 0 ? [] : this.state.contacts.filter(
+      contact => (
+        contact.email &&
+        contact.email.some(
+          email => new RegExp(inputValue).test(email.address)
+        )
+      ) ||
+      (
+        contact.cozy &&
+        contact.cozy.some(
+          cozy => new RegExp(inputValue).test(cozy.url)
+        )
+      )
+    )
   }
 
   onSuggestionsFetchRequested ({ value }) {
-    this.setState({
+    this.setState(state => ({
+      ...state,
       suggestions: this.computeSuggestions(value)
-    })
+    }))
   }
 
   onSuggestionsClearRequested () {
-    this.setState({
+    this.setState(state => ({
+      ...state,
       suggestions: []
-    })
+    }))
   }
 
   onChange (event, { newValue }) {
-    // `newValue` can be a simple string when it's the result of the user typing text, or it can be a contact if it results from an interaction with the autocomplete
-    if (typeof newValue === 'string') {
-      this.props.onChange(newValue)
-    } else {
-      this.props.onChange(this.getPrimaryEmailAddress(newValue), this.getPrimaryCozyUrl(newValue))
-    }
+    const email = getEmail(newValue) || newValue
+    const url = getCozy(newValue)
+    const id = newValue._id
+    this.props.onChange(email, url, id)
   }
 
   render ({ value }, { suggestions }) {
@@ -81,12 +65,12 @@ export default class ShareAutocomplete extends Component {
         getSuggestionValue={contact => contact}
         onSuggestionsFetchRequested={this.onSuggestionsFetchRequested.bind(this)}
         onSuggestionsClearRequested={this.onSuggestionsClearRequested.bind(this)}
-        renderSuggestion={contact =>
+        renderSuggestion={contact => (
           <div>
-            <div className={autosuggestTheme['suggestionPrimary']}>{this.getPrimaryEmailAddress(contact)}</div>
-            <div className={autosuggestTheme['suggestionSecondary']}>{this.getPrimaryCozyUrl(contact)}</div>
+            <div className={autosuggestTheme['suggestionPrimary']}>{getEmail(contact)}</div>
+            <div className={autosuggestTheme['suggestionSecondary']}>{getCozy(contact)}</div>
           </div>
-      }
+        )}
         inputProps={{
           onChange: this.onChange.bind(this),
           value: value

--- a/src/ducks/sharing/components/ShareByEmail.jsx
+++ b/src/ducks/sharing/components/ShareByEmail.jsx
@@ -10,10 +10,10 @@ import styles from '../share.styl'
 
 class ShareByEmail extends React.Component {
 
-  sendSharingLinks (email, sharingType) {
-    return share(this.props.document, email, sharingType)
+  share (recipient, sharingType) {
+    return share(this.props.document, recipient, sharingType)
       .then(sharing => {
-        Alerter.info('Albums.share.shareByEmail.success', { email })
+        Alerter.info('Albums.share.shareByEmail.success', { email: recipient.email })
       })
       .catch(err => {
         Alerter.error('Error.generic')
@@ -24,7 +24,7 @@ class ShareByEmail extends React.Component {
   render () {
     return (
       <div>
-        <ShareByUrl onSend={(email, sharingType) => this.sendSharingLinks(email, sharingType)} />
+        <ShareByUrl onSend={(recipient, sharingType) => this.share(recipient, sharingType)} />
         <WhoHasAccess document={this.props.document} />
       </div>
     )
@@ -36,25 +36,33 @@ class ShareByUrl extends React.Component {
     super(props)
     this.state = {
       email: '',
+      url: undefined,
+      id: undefined,
       sharingType: 'master-slave'
     }
   }
 
-  onAutocomplete (email) {
-    this.changeEmail(email)
+  onAutocomplete (email, url, id) {
+    this.setState(state => ({ ...state, email, url, id }))
   }
 
-  changeEmail (email) {
-    this.setState(state => ({ ...state, email }))
+  reset () {
+    this.setState(state => ({
+      ...state,
+      email: '',
+      url: undefined,
+      id: undefined,
+      sharingType: 'master-slave' }))
   }
 
   sendSharingLink () {
-    this.props.onSend(this.state.email, this.state.sharingType)
+    const {email, url, id, sharingType} = this.state
+    this.props.onSend({email, url, id}, sharingType)
     .then(() => {
-      this.setState(state => ({ ...state, email: '', sharingType: 'master-slave' }))
+      this.reset()
     })
     .catch(() => {
-      this.setState(state => ({ ...state, email: '', sharingType: 'master-slave' }))
+      this.reset()
     })
   }
 
@@ -71,7 +79,9 @@ class ShareByUrl extends React.Component {
           <label className={styles['coz-form-label']} for='email'>{t('Albums.share.shareByEmail.email')}</label>
           <ShareAutocomplete
             value={this.state.email}
-            onChange={(email, url) => this.onAutocomplete(email, url)}
+            onChange={(email, url, id) => {
+              this.onAutocomplete(email, url, id)
+            }}
           />
         </div>
         <div className={classnames(styles['coz-form-controls'], styles['coz-form-controls--dispatch'])}>


### PR DESCRIPTION
If the AutoSuggest/AutoComplete component find a `io.cozy.contacts` with a cozy url, it'll give the tuple.
Then the sharing is using both email and url rather than the discovery tool with only the email.