### PR TITLE
fix: query DATA API

### DIFF
--- a/src/ducks/sharing/components/ShareByEmail.jsx
+++ b/src/ducks/sharing/components/ShareByEmail.jsx
@@ -9,7 +9,6 @@ import { share } from '..'
 import styles from '../share.styl'
 
 class ShareByEmail extends React.Component {
-
   sendSharingLinks (email, sharingType) {
     return share(this.props.document, email, sharingType)
       .then(sharing => {


### PR DESCRIPTION
The response format when calling `cozy.client.files.query` and `cozy.client.data.query` is a bit different. For data, the format is documented [here](
https://github.com/cozy/cozy-stack/blob/master/docs/mango.md#find-documents), but for files, I couldn't find it.

Anyway, right now (AFAIK) we only use `cozy.client.files.query` so everything works fine, but if you try to query the data API (querying `io.cozy.photos.albums` for example) things will explode. So here's a preventive fix for that.
